### PR TITLE
Update items on click

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,7 @@
 <body>
   
   <div id="verticalNavLayout" class="layout-pf layout-pf-fixed faux-layout" ng-controller="vertNavController">
-    <pf-vertical-navigation - -basic items="navigations" brand-alt="NOTES APPLICATION" show-badges="true" pinnable-menus="true" update-active-items-on- click="true">
+    <pf-vertical-navigation - -basic items="navigations" brand-alt="NOTES APPLICATION" show-badges="true" pinnable-menus="true" update-active-items-on-click="true">
     </pf-vertical-navigation - -basic>
      <div id="contentContainer" class="container-fluid container-cards-pf container-pf-nav-pf-vertical">
         <div>


### PR DESCRIPTION
The navigation items had the `update-active-items-on-click` attribute set to true, but there was an error in the formatting (space after `on-`), which meant that it did not execute. This PR fixes that.